### PR TITLE
Catch JSONDecodeError

### DIFF
--- a/itunespy/__init__.py
+++ b/itunespy/__init__.py
@@ -62,6 +62,8 @@ def search(
     try:
         json = r.json()['results']
         result_count = r.json()['resultCount']
+    except JSONDecodeError:
+        raise RuntimeError(general_no_connection)
     except:
         raise ConnectionError(general_no_connection)
 
@@ -106,7 +108,9 @@ def lookup(
     try:
         json = r.json()['results']
         result_count = r.json()['resultCount']
-    except (JSONDecodeError, KeyError):
+    except JSONDecodeError:
+        raise RuntimeError(general_no_connection)
+    except KeyError:
         raise ConnectionError(general_no_connection)
 
     if result_count == 0:

--- a/itunespy/__init__.py
+++ b/itunespy/__init__.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, List, Union
 
 import pycountry
 import requests
+from json.decoder import JSONDecodeError
 from urllib.parse import urlencode
 from itunespy import artist
 from itunespy import music_artist
@@ -105,7 +106,7 @@ def lookup(
     try:
         json = r.json()['results']
         result_count = r.json()['resultCount']
-    except KeyError:
+    except (JSONDecodeError, KeyError):
         raise ConnectionError(general_no_connection)
 
     if result_count == 0:


### PR DESCRIPTION
Attempt to fix #16

An alternative solution would be a `catch-all except`, similar to what is used in `search` function